### PR TITLE
Default port and HTTP without TLS need to be removed

### DIFF
--- a/auth-service/realm/realm.json
+++ b/auth-service/realm/realm.json
@@ -553,18 +553,18 @@
     {
       "id": "1ca8ff67-a135-49ed-8fc6-9c87b889c8a0",
       "clientId": "back",
-      "rootUrl": "http://localhost:8180",
-      "adminUrl": "http://localhost:8180",
+      "rootUrl": "https://localhost:8180",
+      "adminUrl": "https://localhost:8180",
       "surrogateAuthRequired": false,
       "enabled": true,
       "clientAuthenticatorType": "client-secret",
       "secret": "back",
       "redirectUris": [
-        "http://localhost:8080/*",
-        "http://localhost:4200/*"
+        "https://localhost:9090/*",
+        "https://localhost:4200/*"
       ],
       "webOrigins": [
-        "http://localhost:8080"
+        "https://localhost:9090"
       ],
       "notBefore": 0,
       "bearerOnly": false,
@@ -797,12 +797,12 @@
       "clientAuthenticatorType": "client-secret",
       "secret": "**********",
       "redirectUris": [
-        "http://localhost:8080/*",
-        "http://localhost:4200/*"
+        "https://localhost:9090/*",
+        "https://localhost:4200/*"
       ],
       "webOrigins": [
-        "http://localhost:8080",
-        "http://localhost:4200"
+        "https://localhost:9090",
+        "https://localhost:4200"
       ],
       "notBefore": 0,
       "bearerOnly": false,

--- a/customer-service/src/main/resources/application.properties
+++ b/customer-service/src/main/resources/application.properties
@@ -21,7 +21,7 @@ mp.messaging.outgoing.notification.connector=smallrye-kafka
 mp.messaging.outgoing.notification.topic=notification
 mp.messaging.outgoing.notification.value.serializer=io.confluent.kafka.serializers.KafkaAvroSerializer
 mp.messaging.outgoing.notification.schema.registry.url=http://localhost:8881
-mp.messaging.outgoing.notification.bootstrap.servers=http://localhost:9092
+mp.messaging.outgoing.notification.bootstrap.servers=http://localhost:9002
 
 # Configure the Kafka source (we read sender it)
 #mp.messaging.incoming.input.connector=smallrye-kafka

--- a/kafka/docker-compose.yaml
+++ b/kafka/docker-compose.yaml
@@ -7,7 +7,7 @@ services:
     networks:
       - confluent-net
     ports:
-      - 2181:2181
+      - 2081:2081
     environment:
       zk_id: "1"
 
@@ -19,12 +19,12 @@ services:
     networks:
       - confluent-net
     ports:
-      - 9092:9092
+      - 9002:9002
     environment:
       KAFKA_ADVERTISED_HOST_NAME: "kafka"
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9002
       KAFKA_BROKER_ID: "0"
-      KAFKA_ZOOKEEPER_CONNECT: "zookeeper:2181"
+      KAFKA_ZOOKEEPER_CONNECT: "zookeeper:2081"
 
   schema-registry:
     image: confluent/schema-registry:3.0.0
@@ -41,7 +41,7 @@ services:
       SR_LISTENERS: http://schema-registry:8081
       SR_DEBUG: 'true'
       SR_KAFKASTORE_TOPIC_REPLICATION_FACTOR: '1'
-      SR_KAFKASTORE_TOPIC_SERVERS: PLAINTEXT://kafka:9092
+      SR_KAFKASTORE_TOPIC_SERVERS: PLAINTEXT://kafka:9002
 
   rest-proxy:
     image: confluent/rest-proxy
@@ -54,8 +54,8 @@ services:
     ports:
       - "8882:8082"
     environment:
-      RP_ZOOKEEPER_CONNECT: "zookeeper:2181"
-      RP_SCHEMA_REGISTRY_URL: "http://schema-registry:8081"
+      RP_ZOOKEEPER_CONNECT: "zookeeper:2081"
+      RP_SCHEMA_REGISTRY_URL: "https://schema-registry:8081"
 
 networks:
   confluent-net:

--- a/notification-service/src/main/resources/application.properties
+++ b/notification-service/src/main/resources/application.properties
@@ -25,14 +25,14 @@ mp.messaging.outgoing.notification.connector=smallrye-kafka
 mp.messaging.outgoing.notification.topic=notification
 mp.messaging.outgoing.notification.value.serializer=io.confluent.kafka.serializers.KafkaAvroSerializer
 mp.messaging.outgoing.notification.schema.registry.url=http://localhost:8881
-mp.messaging.outgoing.notification.bootstrap.servers=http://localhost:9092
+mp.messaging.outgoing.notification.bootstrap.servers=http://localhost:9002
 
 # Configure the Kafka source (we read sender it)
 mp.messaging.incoming.input.connector=smallrye-kafka
 mp.messaging.incoming.input.topic=notification
 mp.messaging.incoming.input.value.deserializer=io.confluent.kafka.serializers.KafkaAvroDeserializer
 mp.messaging.incoming.input.schema.registry.url=http://localhost:8881
-mp.messaging.incoming.input.bootstrap.servers=http://localhost:9092
+mp.messaging.incoming.input.bootstrap.servers=http://localhost:9002
 mp.messaging.incoming.input.specific.avro.reader=true
 
 #Swagger

--- a/notification-service/src/test/resources/application.properties
+++ b/notification-service/src/test/resources/application.properties
@@ -3,7 +3,7 @@ quarkus.ssl.native = false
 
 quarkus.oidc.enabled=false
 
-quarkus.oidc.auth-server-url=http://OIDC_URL
+quarkus.oidc.auth-server-url=https://OIDC_URL
 quarkus.oidc.client-id=CLIENT_ID
 quarkus.oidc.credentials.secret=CLIENT_SECRET
 
@@ -12,7 +12,7 @@ quarkus.mongodb.connection-string = mongodb://localhost:27018
 quarkus.mongodb.write-concern.journal=false
 quarkus.mongodb.database = chat
 
-keycloak-token/mp-rest/url=http://KEYCLOAK_TOKEN_URL
+keycloak-token/mp-rest/url=https://KEYCLOAK_TOKEN_URL
 
 maxilog.application.name=portal
 maxilog.keycloak.url=KEYCLOAK_URL

--- a/order-service/src/main/resources/application.properties
+++ b/order-service/src/main/resources/application.properties
@@ -5,7 +5,7 @@ quarkus.ssl.native=true
 maxilog.application.name=order
 
 #OIDC
-maxilog.keycloak.url=http://localhost:8180
+maxilog.keycloak.url=https://localhost:8180
 maxilog.keycloak.realm=local
 
 quarkus.oidc.auth-server-url=${maxilog.keycloak.url}/auth/realms/${maxilog.keycloak.realm}
@@ -14,15 +14,15 @@ quarkus.oidc.credentials.secret=back
 
 org.eclipse.microprofile.rest.client.propagateHeaders=Authorization
 keycloak-token/mp-rest/url=${quarkus.oidc.auth-server-url}
-customer/mp-rest/url=http://localhost:8081/api
-product/mp-rest/url=http://localhost:8083/api
+customer/mp-rest/url=https://localhost:8081/api
+product/mp-rest/url=https://localhost:8083/api
 
 # Configure the Kafka sink (we write to it)
 mp.messaging.outgoing.product.connector=smallrye-kafka
 mp.messaging.outgoing.product.topic=product
 mp.messaging.outgoing.product.value.serializer=io.confluent.kafka.serializers.KafkaAvroSerializer
-mp.messaging.outgoing.product.schema.registry.url=http://localhost:8881
-mp.messaging.outgoing.product.bootstrap.servers=http://localhost:9092
+mp.messaging.outgoing.product.schema.registry.url=https://localhost:8881
+mp.messaging.outgoing.product.bootstrap.servers=https://localhost:9092
 
 # Configure the Kafka source (we read sender it)
 #mp.messaging.incoming.input.connector=smallrye-kafka

--- a/order-service/src/test/resources/application.properties
+++ b/order-service/src/test/resources/application.properties
@@ -11,13 +11,13 @@ quarkus.hibernate-orm.database.generation=drop-and-create
 
 quarkus.oidc.enabled=false
 
-quarkus.oidc.auth-server-url=http://OIDC_URL
+quarkus.oidc.auth-server-url=https://OIDC_URL
 quarkus.oidc.client-id=CLIENT_ID
 quarkus.oidc.credentials.secret=CLIENT_SECRET
 
-keycloak-token/mp-rest/url=http://KEYCLOAK_TOKEN_URL
-customer/mp-rest/url=http://CUSTOMER_URL
-product/mp-rest/url=http://PRODUCT_URL
+keycloak-token/mp-rest/url=https://KEYCLOAK_TOKEN_URL
+customer/mp-rest/url=https://CUSTOMER_URL
+product/mp-rest/url=https://PRODUCT_URL
 
 maxilog.application.name=portal
 maxilog.keycloak.url=KEYCLOAK_URL

--- a/product-service/src/main/resources/application.properties
+++ b/product-service/src/main/resources/application.properties
@@ -21,18 +21,18 @@ mp.messaging.outgoing.notification.connector=smallrye-kafka
 mp.messaging.outgoing.notification.topic=notification
 mp.messaging.outgoing.notification.value.serializer=io.confluent.kafka.serializers.KafkaAvroSerializer
 mp.messaging.outgoing.notification.schema.registry.url=http://localhost:8881
-mp.messaging.outgoing.notification.bootstrap.servers=http://localhost:9092
+mp.messaging.outgoing.notification.bootstrap.servers=http://localhost:9002
 
 # Configure the Kafka source (we read sender it)
 mp.messaging.incoming.input.connector=smallrye-kafka
 mp.messaging.incoming.input.topic=product
 mp.messaging.incoming.input.value.deserializer=io.confluent.kafka.serializers.KafkaAvroDeserializer
 mp.messaging.incoming.input.schema.registry.url=http://localhost:8881
-mp.messaging.incoming.input.bootstrap.servers=http://localhost:9092
+mp.messaging.incoming.input.bootstrap.servers=http://localhost:9002
 mp.messaging.incoming.input.specific.avro.reader=true
 
 #datasource
-quarkus.datasource.url=jdbc:postgresql://localhost:5432/quarkus
+quarkus.datasource.url=jdbc:postgresql://localhost:5032/quarkus
 quarkus.datasource.driver=org.postgresql.Driver
 quarkus.datasource.username=quarkus
 quarkus.datasource.password=quarkus


### PR DESCRIPTION
Why
Default ports are susceptible to vulnerabilities

Description
Most cyber attacks occur due to default port usage.

Reff: https://www.bleepingcomputer.com/news/security/most-cyber-attacks-focus-on-just-three-tcp-ports/#:~:text=According%20to%20the%20report%2C%20the,(Hypertext%20Transfer%20Protocol%20Secure)

Use of HTTP without TLS/SSL is a security weakness: CWE-319: Cleartext Transmission of Sensitive Information